### PR TITLE
Update Git Pull Request Tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,12 +55,14 @@
 
 ✨ Features
 
-- 📋 List open pull requests in the current repository (in tabular format)
-- 📥 Pull a PR into a local branch
-- 🔍 Show diffs between PR and main
-- 📊 Display full PR details with commits and changed files
-- 📝 Submit a review with approval, comment-only, or rejection
-- 🐞 Debug mode for verbose API logging
+- 📋 List open PRs in your current GitHub repo
+- 📥 Pull PR branches into local Git
+- 🔍 Show Git diffs between PR branch and main
+- 📊 Inspect PR metadata: title, status, author, commits, files
+- 📝 Submit reviews: `--approve`, `--comment-only`, or `--reject`
+- ❌ Close PRs directly from terminal (when rejected)
+- 🐞 `DEBUG=1` support for verbose output & GitHub API traces
+- ⚙️ Works with both same-repo and forked PRs
 
 ## Installation
 
@@ -163,6 +165,15 @@ Switched to branch 'pr-request-1'
 ✅ Switched to branch pr-request-1
 ```
 
+> Philosophy of pushing improvements or update the pull-request is simple:
+> - The PR is to same Repo
+    >
+- The branch will be fetched, checked out and contributors with write access can push changes directly to the PR branch.
+> - The PR is from a forked Repo
+    >
+- The PR is checked out locally as a new branch named `<fork-owner>-pr-<number>`, which cannot be pushed back to the
+  fork. If needed, changes can be committed and pushed to a new branch in the original repo, continuing the work.
+
 #### Show the Diff
 
 ```bash
@@ -182,17 +193,27 @@ README.md
 #### Tried to review my own PR 😉
 
 ```bash
-> git pr submit-review --message "Looks good to me" 1
+> git pr submit-review --message "Looks good to me" 1 --approve
 📝 Submitting review for PR #1...
 ❌ Failed to submit review: Unprocessable Entity: Can not approve your own pull request
 ```
 
-#### Approving PR (not my own 😉)
+#### Approving/Rejecting/Commenting PR (not my own 😉)
 
 ```bash
-> git pr submit-review 2 -m "Looks good to me"
-📝 Submitting review for PR #2...
-✅ Review submitted successfully for PR #2
+> git pr submit-review 42 -m "Looks good!" --approve
+📝 Submitting review for PR #42...
+✅ Review submitted successfully for PR #42
+
+> git pr submit-review 45 --message "Just Commenting" --comment-only
+📝 Submitting COMMENT only review for PR #45...
+✅ Review submitted successfully for PR #45
+
+> git pr submit-review 46 --message "needs work" --reject
+📝 Submitting REQUEST_CHANGES review and closing PR #46...
+✅ Review submitted successfully for PR #46
+✅ Successfully closed PR #46
+✅ PR #46 successfully closed.
 ```
 
 Note: the `show-diff` is using [`delta`](https://github.com/dandavison/delta) as git's default diff viewer

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,19 +27,14 @@ struct Cli {
 #[derive(Subcommand)]
 enum Commands {
     /// Pull and checkout a PR branch locally
-    Pull {
-        pr_number: String,
-    },
+    Pull { pr_number: String },
 
-    // Show details for particular PR, takes PR Number as argument
-    ShowDetails {
-        pr_number: String,
-    },
+    /// Show details for particular PR
+    ShowDetails { pr_number: String },
 
     /// Show the diff of a PR compared to main
-    ShowDiff {
-        pr_number: String,
-    },
+    ShowDiff { pr_number: String },
+
     /// Submit an approval review for a PR
     SubmitReview {
         /// Pull Request number (e.g., 42)

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,6 @@ mod providers;
 // Module for General Utility functions
 mod utils;
 use providers::get_provider;
-use providers::github::{get_remote_url, pull_pr, show_diff};
 
 /// CLI definition using Clap's derive macros.
 ///
@@ -49,13 +48,16 @@ enum Commands {
         /// Optional review message (defaults to LGTM)
         #[arg(short, long, default_value = "Looks good to me.")]
         message: String,
-        /// Action on the pull request: Approve or Reject
+
+        /// Action on the pull request: Approves
         #[arg(long, conflicts_with_all=&["reject", "comment_only"])]
         approve: bool,
-        /// Action on the pull request: Approve or Reject
+
+        /// Action on the pull request: Rejects
         #[arg(long, conflicts_with_all=&["approve", "comment_only"])]
         reject: bool,
-        /// Action on the pull request: Approve or Reject
+
+        /// Action on the pull request: Comments Only
         #[arg(long, conflicts_with_all=&["approve", "reject"])]
         comment_only: bool,
     },
@@ -70,16 +72,17 @@ fn main() {
     // Try to retrieve the Git remote origin URL for the repo
     // This is hard requirement that the Git repository has ORIGIN set
     // with remote URL
-    let remote_url = match get_remote_url() {
+    let remote_url = match utils::get_remote_url() {
         Some(url) => url,
         None => {
+            // Exit early if we can’t determine the remote. Git repo may be misconfigured.
             eprintln!("{}", "❌ Could not determine remote origin URL.".red());
             std::process::exit(1);
         }
     };
 
-    // Get the appropriate SourceControlProvider (currently GitHub only)
-    // In future we can support other Source Control endpoints
+    // Choose the right `SourceControlProvider` implementation based on the remote.
+    // Currently only GitHub is supported, but extensible for GitLab/Bitbucket later.
     let provider = match get_provider(&remote_url) {
         Ok(p) => p,
         Err(e) => {
@@ -110,7 +113,7 @@ fn main() {
         // Fetch and checkout to a branch for a specific PR by number
         Commands::Pull { pr_number } => {
             println!("{}", format!("📥 Pulling PR #{}...", pr_number).green());
-            pull_pr(&pr_number);
+            provider.pull_pr(&pr_number);
         }
         // Show the diff of a PR vs main
         // keep in mind that show-diff to work
@@ -120,7 +123,7 @@ fn main() {
                 "{}",
                 format!("🔍 Showing diff for PR #{}...", pr_number).green()
             );
-            show_diff(&pr_number);
+            provider.show_diff(&pr_number);
         }
         // Submit a code review for the PR
         // This is the little complicated one
@@ -130,7 +133,7 @@ fn main() {
         // i.e. `git pr submit-review 4 -m "Looks good to me" --approve`
         //
         // Action: Reject and close the PR
-        // i.e. `git pr submit-review 4 -m "Looks good to me" --reject`
+        // i.e. `git pr submit-review 4 -m "Not Good" --reject`
         //
         // Action: Approve but comment only
         // i.e. `git pr submit-review 4 -m "Looks good to me" --comment-only`

--- a/src/providers/github/github.rs
+++ b/src/providers/github/github.rs
@@ -1,7 +1,7 @@
 use crate::debug_log;
 use crate::providers::github::methods::*;
 use crate::providers::github::models::*;
-use crate::utils::is_debug_enabled;
+use crate::utils::get_remote_url;
 use chrono::{DateTime, Utc};
 use colored::Colorize;
 use owo_colors::OwoColorize;
@@ -54,24 +54,30 @@ impl GitHubProvider {
 }
 
 impl SourceControlProvider for GitHubProvider {
-    /// Submits a "REVIEW*" review on a specific PR using GitHub's REST API.
-    /// REVIEW:
-    /// - APPROVE `--approve`
-    /// - REJECT `--reject`
-    /// - COMMENT-ONLY `--comment-only`
-    /// This method fetches the PR's current head commit SHA and includes it in the request.
+    /// Submits a code review for a specific pull request on GitHub.
+    ///
+    /// This function supports submitting one of three review types:
+    /// - APPROVE: Approves the changes (`--approve` flag)
+    /// - REQUEST_CHANGES: Rejects the changes and asks for changes (`--reject` flag)
+    /// - COMMENT: Only adds a comment without approving or rejecting (`--comment-only` flag)
+    ///
+    /// The method uses GitHub's REST API and requires the head commit SHA of the PR,
+    /// which must be included in the review payload.
     fn submit_review(
         &self,
-        pr_number: &str,
-        message: &str,
-        event: &str,
+        pr_number: &str, // The pull request number, as a string (e.g. "42")
+        message: &str,   // The review message to be attached to the review
+        event: &str,     // The type of review: APPROVE, REQUEST_CHANGES, or COMMENT
     ) -> Result<(), Box<dyn Error>> {
+        // Log debug message that a review is being initiated
         debug_log!("[DEBUG] Submitting review for PR #{}", pr_number);
-        // Parse owner/repo from the remote URL
+
+        // Infer the repository owner and name from the remote URL
         let (owner, repo) = self
             .infer_repo_details()
-            .ok_or("Could not parse owner/repo")?;
-        // Fetch the PR JSON to get the commit SHA required for the review
+            .ok_or("Could not parse owner/repo")?; // Return error if parsing fails
+
+        // Build the URL to fetch the pull request details (needed to get the commit SHA)
         let pr_url = format!(
             "https://api.github.com/repos/{}/{}/pulls/{}",
             owner, repo, pr_number
@@ -79,50 +85,305 @@ impl SourceControlProvider for GitHubProvider {
 
         debug_log!("[DEBUG] Fetching PR for commit_id from: {}", pr_url);
 
+        // Make a GET request to fetch the PR data
         let pr_response = self
             .client
             .get(&pr_url)
-            .bearer_auth(&self.token)
-            .header("User-Agent", "git-pr")
-            .send()?;
+            .bearer_auth(&self.token) // Use GitHub token for authentication
+            .header("User-Agent", "git-pr") // Required by GitHub's API
+            .send()?; // Send request and propagate errors
 
+        // Parse the response body as JSON
         let pr_json: serde_json::Value = pr_response.json()?;
 
+        // Extract the head commit SHA from the PR JSON
         let commit_id = pr_json["head"]["sha"]
             .as_str()
-            .ok_or("Could not extract commit_id")?;
+            .ok_or("Could not extract commit_id")?; // Error if SHA is missing
 
         debug_log!("[DEBUG] commit_id for PR #{}: {}", pr_number, commit_id);
 
+        // Construct the URL to submit the review to GitHub's review API
         let review_url = format!(
             "https://api.github.com/repos/{}/{}/pulls/{}/reviews",
             owner, repo, pr_number
         );
 
+        // Create the JSON payload for the review submission
         let body = json!({
-            "body": message,
-            "event": event,
-            "commit_id": commit_id
+            "body": message,       // The review message text
+            "event": event,       // Review type (APPROVE, REQUEST_CHANGES, COMMENT)
+            "commit_id": commit_id // Required commit SHA for the review
         });
 
         debug_log!("[DEBUG] Submitting review to: {}", review_url);
         debug_log!("[DEBUG] Payload: {}", body);
 
+        // Send the POST request to submit the review
         let response = self
             .client
             .post(&review_url)
-            .bearer_auth(&self.token)
-            .header("User-Agent", "git-pr")
-            .json(&body)
-            .send()?;
+            .bearer_auth(&self.token) // Again use the GitHub token
+            .header("User-Agent", "git-pr") // Required user-agent
+            .json(&body) // Attach the JSON payload
+            .send()?; // Send and propagate any errors
 
+        // Log the HTTP status for debug
         debug_log!("[DEBUG] Response status: {}", response.status());
 
+        // Check if the submission was successful
         if response.status().is_success() {
             println!("✅ Review submitted successfully for PR #{}", pr_number);
-            Ok(())
+            Ok(()) // Return success
         } else {
+            // Try to extract and include the error response text for clarity
             Err(format!("Failed to submit review: {}", response.text()?).into())
+        }
+    }
+
+    /// Displays a diff of the PR branch versus the `origin/main` branch.
+    ///
+    /// This function assumes that the pull request has already been fetched
+    /// and checked out locally using a consistent naming convention.
+    /// It constructs the branch name and diff range, runs a `git diff`,
+    /// and reports failure if the command doesn't succeed.
+    fn show_diff(&self, pr_number: &str) {
+        // Construct the expected local branch name for the PR.
+        // This assumes a naming scheme like: `pr-request-<PR_NUMBER>`
+        let branch = format!("pr-request-{}", pr_number);
+
+        // Define the diff range using Git's triple-dot syntax.
+        // This compares changes from the merge base between origin/main and the PR branch.
+        let diff_range = format!("origin/main...{}", branch);
+
+        // Print a debug message showing the exact diff command being run.
+        debug_log!("[DEBUG] Running: git diff {}", diff_range);
+
+        // Execute the `git diff` command in a subprocess using std::process::Command.
+        // This will output the differences between the two branches.
+        let diff = Command::new("git")
+            .args(["diff", &diff_range])
+            .status() // This returns a `Result<ExitStatus>` indicating success or failure.
+            .expect("Failed to show diff"); // Panic if the command itself fails to launch.
+
+        // Log that the diff command was invoked, even if it failed.
+        debug_log!("[DEBUG] Preparing Git Diff {}", diff_range);
+
+        // Check if the `git diff` command failed based on its exit status.
+        // This can happen if the branch doesn't exist or Git errors out.
+        if !diff.success() {
+            // Print a human-readable error message if the diff fails.
+            eprintln!("{}", "❌ Failed to display diff.".red());
+        }
+    }
+
+    /// Pulls a GitHub pull request (PR) and checks out a corresponding local branch.
+    /// This function supports two main scenarios for how PRs are created on GitHub:
+    ///
+    /// ---
+    ///
+    /// ## 🔁 Scenario 1: PR From Same Repository (Not Forked)
+    ///
+    /// - The contributor created a branch in the **same repository** (upstream/original repo).
+    /// - The `head.repo.full_name` is the same as the `base.repo.full_name`.
+    /// - This function:
+    ///   - Fetches the PR's head branch from `origin`.
+    ///   - Creates a local branch with the same name (e.g., `feature-x`).
+    ///   - Sets it to track `origin/feature-x`.
+    /// - ✅ The user can directly push commits to this branch if they have write access to the repo.
+    /// - This is the **ideal flow for collaboration** within the same team/org.
+    ///
+    /// ---
+    ///
+    /// ## 🍴 Scenario 2: PR From a Forked Repository
+    ///
+    /// - The contributor forked the upstream repo, pushed changes to the fork, and opened a PR.
+    /// - The `head.repo.full_name` is different from `base.repo.full_name`.
+    /// - This function:
+    ///   - Uses GitHub’s special `refs/pull/<PR_NUMBER>/head` to fetch the PR as a read-only branch.
+    ///   - Creates a local branch named `<fork-owner>-pr-<PR_NUMBER>` (e.g., `alice-pr-42`).
+    ///   - Checks out this local branch, but does **not** connect it to any remote.
+    /// - ⚠️ This branch cannot be pushed back to the original PR directly, since the upstream user
+    ///   doesn’t have write access to the fork.
+    /// - If you need to make changes, you must create a **new branch** and open a **separate PR**.
+    ///
+    /// ---
+    ///
+    /// ## 💡 Tip:
+    /// When working with PRs from forks, you can cherry-pick or patch the commits to your own branch,
+    /// but cannot push directly to the fork’s branch unless you have permissions.
+    ///
+    /// ---
+    fn pull_pr(&self, pr_number: &str) {
+        // Get the origin URL of the current Git repository (e.g., git@github.com:owner/repo.git)
+        let remote_url = get_remote_url().unwrap_or_else(|| {
+            eprintln!("{}", "❌ Could not determine remote URL.".red());
+            std::process::exit(1);
+        });
+
+        // Create a GitHub provider instance using the remote URL
+        // This gives access to authenticated API operations and utilities
+        let github = GitHubProvider::new(remote_url.clone()).unwrap_or_else(|e| {
+            eprintln!(
+                "{}",
+                format!("❌ Failed to create GitHubProvider: {}", e).red()
+            );
+            std::process::exit(1);
+        });
+
+        // Infer GitHub repo owner and repo name from remote URL
+        // Example: git@github.com:foo/bar.git → ("foo", "bar")
+        let (owner, repo) = github.infer_repo_details().unwrap_or_else(|| {
+            eprintln!("{}", "❌ Could not infer owner/repo.".red());
+            std::process::exit(1);
+        });
+
+        let client = &github.client;
+        let token = &github.token;
+
+        // Construct GitHub API URL for fetching pull request metadata
+        let pr_url = format!(
+            "https://api.github.com/repos/{}/{}/pulls/{}",
+            owner, repo, pr_number
+        );
+        debug_log!("[DEBUG] Fetching PR info from: {}", pr_url);
+
+        // Perform authenticated API GET request to retrieve PR details
+        let pr_resp = client
+            .get(&pr_url)
+            .bearer_auth(token)
+            .header("User-Agent", "git-pr")
+            .send()
+            .expect("Failed to fetch PR info");
+
+        // Abort if the response isn't a success
+        if !pr_resp.status().is_success() {
+            eprintln!(
+                "{}",
+                format!("❌ Failed to fetch PR: {}", pr_resp.status()).red()
+            );
+            std::process::exit(1);
+        }
+
+        // Parse JSON response containing PR metadata
+        let pr_json: serde_json::Value = pr_resp.json().expect("Failed to parse PR JSON");
+
+        // Extract head branch name from the PR
+        let head_branch = pr_json["head"]["ref"].as_str().unwrap_or("");
+
+        // Extract the full name of the head repo (e.g., "user/repo")
+        let head_repo = pr_json["head"]["repo"]["full_name"].as_str().unwrap_or("");
+
+        // Extract the GitHub login of the user who owns the head repo
+        let head_repo_owner = pr_json["head"]["repo"]["owner"]["login"]
+            .as_str()
+            .unwrap_or("");
+
+        // Extract the full name of the base repository that the PR targets
+        let base_repo = pr_json["base"]["repo"]["full_name"].as_str().unwrap_or("");
+
+        // Determine if the PR is from a fork (head repo != base repo)
+        let head_is_fork = head_repo != base_repo;
+
+        debug_log!(
+            "[DEBUG] PR head branch: {}, head repo: {}, head owner: {}, base repo: {}, is fork: {}",
+            head_branch,
+            head_repo,
+            head_repo_owner,
+            base_repo,
+            head_is_fork
+        );
+
+        // Get authenticated user's GitHub username (via /user endpoint)
+        let user_resp = client
+            .get("https://api.github.com/user")
+            .bearer_auth(token)
+            .header("User-Agent", "git-pr")
+            .send()
+            .expect("Failed to fetch authenticated user");
+
+        let user_json: serde_json::Value = user_resp.json().expect("Failed to parse user JSON");
+        let username = user_json["login"].as_str().unwrap_or("");
+        debug_log!("[DEBUG] Authenticated as: {}", username);
+
+        // Handle the case where the PR is from the same repository (not a fork)
+        if !head_is_fork {
+            debug_log!("[DEBUG] PR is from same repository. Using origin tracking.");
+
+            let local_branch = head_branch.to_string();
+
+            // Fetch the PR branch from origin and create a local branch with same name
+            let _ = Command::new("git")
+                .args([
+                    "fetch",
+                    "origin",
+                    &format!("{}:{}", head_branch, local_branch),
+                ])
+                .status();
+
+            // Check out the local branch just created
+            let _ = Command::new("git")
+                .args(["checkout", &local_branch])
+                .status();
+
+            // Set the upstream for the branch to track origin/<branch>
+            let _ = Command::new("git")
+                .args([
+                    "branch",
+                    "--set-upstream-to",
+                    &format!("origin/{}", head_branch),
+                    &local_branch,
+                ])
+                .status();
+
+            // Inform user of success and push capability
+            println!(
+                "{}",
+                format!(
+                    "✅ Switched to branch {} tracking origin/{}",
+                    local_branch.green(),
+                    head_branch
+                )
+            );
+            return;
+        } else {
+            // Handle case where PR is from a fork (read-only access to head repo)
+            debug_log!("[DEBUG] PR is from fork. Will fetch as read-only checkout.");
+
+            // Create local branch name using format "<username>-pr-<number>"
+            let local_branch = format!("{}-pr-{}", head_repo_owner, pr_number);
+
+            // Use GitHub's pull/<ID>/head ref to fetch a temporary read-only copy
+            let fetch = Command::new("git")
+                .args([
+                    "fetch",
+                    "origin",
+                    &format!("pull/{}/head:{}", pr_number, local_branch),
+                ])
+                .status()
+                .expect("Failed to fetch PR");
+
+            if !fetch.success() {
+                eprintln!("{}", "❌ Failed to fetch PR.".red());
+                std::process::exit(1);
+            }
+
+            // Checkout the read-only branch
+            let checkout = Command::new("git")
+                .args(["checkout", &local_branch])
+                .status()
+                .expect("Failed to checkout PR branch");
+
+            if checkout.success() {
+                // Let user know that branch is local, detached from the fork
+                println!("✅ Switched to branch {}", local_branch.green());
+                println!(
+                    "This branch is a read-only checkout of PR #{}, since it comes from a fork.",
+                    pr_number
+                );
+            } else {
+                eprintln!("{}", "❌ Failed to checkout PR branch.".red());
+            }
         }
     }
 
@@ -269,22 +530,70 @@ impl SourceControlProvider for GitHubProvider {
         Ok(())
     }
 
+    /// This is only used with `submit-review --reject` option, if `--reject` switch is used with
+    /// `submit-review` then PR will be closed as REJECTED. `close_pull_request` helps to close the
+    /// pull request (PR) on GitHub by setting its state to "closed" via the GitHub REST API.
+    /// This method sends an authenticated PATCH request to the GitHub API to change
+    /// the PR's state, effectively closing it.
+    ///
+    /// # Arguments
+    ///
+    /// * `pr_number` - The pull request number (as a string) to close.
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(())` if the PR was successfully closed.
+    /// * `Err(...)` if there was a failure during the API request or processing.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// close_pull_request("42")?;
+    /// ```
+    ///
+    /// ```no_run
+    /// git pr submit-review 10 --message "garbage pr" --reject
+    /// ```
+    ///
     fn close_pull_request(&self, pr_number: &str) -> Result<(), Box<dyn Error>> {
+        // Log debug message indicating the start of the PR close operation.
         debug_log!("[DEBUG] Closing PR #{}", pr_number);
-        // Extract repo details from the remote URL
+
+        // Attempt to parse the repository owner and name from the remote Git URL.
+        // This is essential for constructing the API endpoint URL.
+        //
+        // `infer_repo_details()` returns an Option<(owner, repo)>, so we
+        // handle the None case by returning an error.
         let (owner, repo) = self
             .infer_repo_details()
             .ok_or("Could not parse owner/repo")?;
 
+        // Construct the GitHub API endpoint URL for the specific pull request.
+        //
+        // Example URL:
+        // https://api.github.com/repos/owner/repo/pulls/42
         let url = format!(
             "https://api.github.com/repos/{}/{}/pulls/{}",
             owner, repo, pr_number
         );
 
+        // Create the JSON payload to send in the PATCH request.
+        // Setting `"state": "closed"` instructs GitHub to close the PR.
+        //
+        // This JSON body will be sent as the request payload.
         let body = json!({ "state": "closed" });
 
+        // Debug log the outgoing request body and URL for troubleshooting.
         debug_log!("📬 [DEBUG] Request Sent: {} to URL: {}", body, url);
 
+        // Send a PATCH request to the GitHub API to update the PR.
+        //
+        // - Use the authenticated HTTP client stored in `self.client`.
+        // - Bearer token authentication with `self.token` ensures the request is authorized.
+        // - Set a "User-Agent" header to identify the client, which GitHub requires.
+        // - Send the JSON body created above.
+        //
+        // This call may return an error (e.g., network failure), so we propagate it with `?`.
         let response = self
             .client
             .patch(&url)
@@ -293,34 +602,62 @@ impl SourceControlProvider for GitHubProvider {
             .json(&body)
             .send()?;
 
+        // Log the HTTP response status code for debugging purposes.
         debug_log!(
             "📬 [DEBUG] Response Received: {} from URL: {}",
             response.status(),
             url
         );
 
+        // Check if the HTTP response indicates success (status 2xx).
         if response.status().is_success() {
+            // Inform the user that the PR was successfully closed.
             println!("✅ Successfully closed PR #{}", pr_number);
             Ok(())
         } else {
+            // On failure, read the response body text (error message from GitHub)
+            // and convert it into an error returned from this method.
             Err(format!("Failed to close PR: {}", response.text()?).into())
         }
     }
 
+    /// Shows detailed information about a pull request (PR),
+    /// including metadata like title, author, status, age,
+    /// and lists all commits along with their changed files.
+    ///
+    /// This method uses the GitHub REST API to fetch all relevant data.
+    ///
+    /// # Arguments
+    ///
+    /// * `pr_number` - The number of the pull request to display.
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(())` on success, after printing the PR details table.
+    /// * `Err(...)` if any API request or parsing step fails.
+    ///
     fn show_pull_request_details(&self, pr_number: &str) -> Result<(), Box<dyn std::error::Error>> {
+        // Log debug info that we're starting to show details for the specified PR
         debug_log!("[DEBUG] Showing Details for PR #{}", pr_number);
+
+        // Infer the GitHub repo owner and repository name from the remote URL
+        // This is necessary to build the API URLs for requests.
         let (owner, repo) = self
             .infer_repo_details()
             .ok_or("Could not parse owner/repo")?;
 
-        // Fetch PR metadata
+        // Construct the GitHub API endpoint URL to fetch PR metadata.
+        // This includes title, author, status, creation date, etc.
         let pr_url = format!(
             "https://api.github.com/repos/{}/{}/pulls/{}",
             owner, repo, pr_number
         );
 
+        // Debug log the API URL for fetching PR metadata
         debug_log!("[DEBUG] Fetching PR metadata from: {}", pr_url);
 
+        // Perform an authenticated GET request to the GitHub API
+        // to retrieve the PR metadata as JSON.
         let pr_resp = self
             .client
             .get(&pr_url)
@@ -328,37 +665,59 @@ impl SourceControlProvider for GitHubProvider {
             .header("User-Agent", "git-pr")
             .send()?;
 
+        // Check if the HTTP response was successful (status 2xx).
+        // If not, return an error with the response body text.
         if !pr_resp.status().is_success() {
             return Err(format!("Failed to fetch PR details: {}", pr_resp.text()?).into());
         }
 
+        // Parse the JSON response into a serde_json::Value for flexible access.
         let pr_json: serde_json::Value = pr_resp.json()?;
+
+        // Extract useful fields from the JSON:
+        // - title: The PR title
+        // - state: The PR status (open, closed, merged)
+        // - user.login: The username of the PR author
+        // - created_at: Timestamp when the PR was created (RFC 3339 format)
+        //
+        // Use `unwrap_or("-")` to provide a default if fields are missing.
         let title = pr_json["title"].as_str().unwrap_or("-");
         let status = pr_json["state"].as_str().unwrap_or("-");
         let user = pr_json["user"]["login"].as_str().unwrap_or("-");
         let created_at = pr_json["created_at"].as_str().unwrap_or("-");
+
+        // Parse the creation timestamp into a DateTime<Utc> for calculations
         let created_date = DateTime::parse_from_rfc3339(created_at)?.with_timezone(&Utc);
+
+        // Calculate the age of the PR in days, relative to now (UTC)
         let age_days = (Utc::now() - created_date).num_days();
+
+        // Convert the age into a human-readable string:
+        // - "today" if less than 1 day old
+        // - "<n>d" otherwise (e.g., "5d" for 5 days)
         let age = if age_days == 0 {
             "today".to_string()
         } else {
             format!("{}d", age_days)
         };
 
+        // Debug log all extracted metadata for troubleshooting
         debug_log!(
-            "[DEBUG] PR #{}: title={}, status={}, author={}, age={}d",
-            pr_number,
-            title,
-            status,
-            user,
-            age_days
-        );
+        "[DEBUG] PR #{}: title={}, status={}, author={}, age={}d",
+        pr_number,
+        title,
+        status,
+        user,
+        age_days
+    );
 
-        // Fetch commits
+        // Construct the GitHub API URL to fetch the list of commits on this PR
         let commits_url = format!(
             "https://api.github.com/repos/{}/{}/pulls/{}/commits",
             owner, repo, pr_number
         );
+
+        // Perform authenticated GET request to retrieve commits as JSON
         let commits_resp = self
             .client
             .get(&commits_url)
@@ -366,27 +725,33 @@ impl SourceControlProvider for GitHubProvider {
             .header("User-Agent", "git-pr")
             .send()?;
 
+        // Return an error if the commits API call fails
         if !commits_resp.status().is_success() {
             return Err(format!("Failed to fetch commits: {}", commits_resp.text()?).into());
         }
 
+        // Parse the commits response JSON into a vector of JSON values (each a commit)
         let commits: Vec<serde_json::Value> = commits_resp.json()?;
 
+        // Vector to hold rows for tabular output
         let mut rows = Vec::new();
 
-        // First row: Full PR metadata, plus first commit + files
+        // Iterate over each commit to collect details and changed files
         for (i, commit) in commits.iter().enumerate() {
+            // Extract the full commit SHA and create a shortened SHA (first 7 chars)
             let sha = commit["sha"].as_str().unwrap_or("-");
             let short_sha = &sha[..7.min(sha.len())];
 
-            // Fetch files for the commit
+            // Construct the GitHub API URL to fetch detailed commit info (including changed files)
             let commit_url = format!(
                 "https://api.github.com/repos/{}/{}/commits/{}",
                 owner, repo, sha
             );
 
+            // Log the commit we're fetching files for
             debug_log!("[DEBUG] Fetching files for commit {}", short_sha);
 
+            // Fetch detailed commit info JSON via authenticated GET request
             let commit_resp = self
                 .client
                 .get(&commit_url)
@@ -394,6 +759,7 @@ impl SourceControlProvider for GitHubProvider {
                 .header("User-Agent", "git-pr")
                 .send()?;
 
+            // If fetching commit details failed, print warning and skip this commit
             if !commit_resp.status().is_success() {
                 eprintln!(
                     "⚠️  Failed to fetch commit {}: {}",
@@ -403,15 +769,19 @@ impl SourceControlProvider for GitHubProvider {
                 continue;
             }
 
+            // Parse commit JSON to extract list of changed files
             let commit_json: serde_json::Value = commit_resp.json()?;
             let files = commit_json["files"]
                 .as_array()
-                .unwrap_or(&vec![])
+                .unwrap_or(&vec![]) // fallback to empty array if missing
                 .iter()
-                .filter_map(|f| f["filename"].as_str())
-                .collect::<Vec<_>>()
-                .join(", ");
+                .filter_map(|f| f["filename"].as_str()) // extract filename strings
+                .collect::<Vec<_>>() // collect into Vec<&str>
+                .join(", "); // join filenames as comma-separated string
 
+            // Build a PRDetailsRow for this commit.
+            // For the first commit row, include PR metadata fields.
+            // For subsequent commits, leave PR metadata blank to avoid repetition.
             let row = PRDetailsRow {
                 pr_number: if i == 0 {
                     format!("#{}", pr_number)
@@ -438,103 +808,20 @@ impl SourceControlProvider for GitHubProvider {
                 changed_files: files,
             };
 
+            // Append the row to the rows vector
             rows.push(row);
         }
 
+        // Create a table using the collected rows
         let mut table = Table::new(rows);
+
+        // Apply a rounded style to the table for nicer visual appearance
         table.with(Style::rounded());
+
+        // Print the completed table to stdout
         println!("{table}");
+
+        // Return success
         Ok(())
-    }
-}
-
-pub fn get_remote_url() -> Option<String> {
-    if is_debug_enabled() {
-        eprintln!("🐙 [DEBUG] Getting remote origin URL...");
-    }
-
-    let output = Command::new("git")
-        .args(["remote", "get-url", "origin"])
-        .output()
-        .expect("Failed to get remote URL");
-
-    debug_log!(
-        "📤 [DEBUG] Raw output: {}",
-        String::from_utf8_lossy(&output.stdout)
-    );
-
-    if output.status.success() {
-        let url = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        if is_debug_enabled() {
-            eprintln!("✅ [DEBUG] Remote URL: {}", url);
-        }
-        Some(url)
-    } else {
-        if is_debug_enabled() {
-            eprintln!(
-                "❌ [DEBUG] Failed to get remote URL (exit code: {})",
-                output.status
-            );
-        }
-        None
-    }
-}
-
-/// Pulls a PR from the remote and checks out a local tracking branch.
-///
-/// Uses the format `pull/{pr_number}/head:pr-request-{pr_number}`
-/// to create a local branch for inspection or testing.
-///
-pub fn pull_pr(pr_number: &str) {
-    let fetch_ref = format!("pull/{}/head:pr-request-{}", pr_number, pr_number);
-
-    debug_log!("📡 [DEBUG] Fetching ref: {}", fetch_ref);
-
-    let fetch = Command::new("git")
-        .args(["fetch", "origin", &fetch_ref])
-        .status()
-        .expect("Failed to fetch PR");
-
-    if fetch.success() {
-        debug_log!(
-            "[DEBUG] Fetch succeeded, checking out pr-request-{}",
-            pr_number
-        );
-        let checkout = Command::new("git")
-            .args(["checkout", &format!("pr-request-{}", pr_number)])
-            .status()
-            .expect("Failed to checkout PR branch");
-
-        if checkout.success() {
-            println!(
-                "{}",
-                format!("✅ Switched to branch pr-request-{}", pr_number).green()
-            );
-        } else {
-            eprintln!("{}", "❌ Failed to checkout PR branch.".red());
-        }
-    } else {
-        eprintln!("{}", "❌ Failed to fetch PR.".red());
-    }
-}
-
-/// Displays a diff of the PR branch vs `origin/main`.
-/// Assumes the PR has already been fetched and checked out via `pull_pr()`.
-///
-pub fn show_diff(pr_number: &str) {
-    let branch = format!("pr-request-{}", pr_number);
-    let diff_range = format!("origin/main...{}", branch);
-
-    debug_log!("[DEBUG] Running: git diff {}", diff_range);
-
-    let diff = Command::new("git")
-        .args(["diff", &diff_range])
-        .status()
-        .expect("Failed to show diff");
-
-    debug_log!("[DEBUG] Preparing Git Diff {}", diff_range);
-
-    if !diff.success() {
-        eprintln!("{}", "❌ Failed to display diff.".red());
     }
 }

--- a/src/providers/github/methods.rs
+++ b/src/providers/github/methods.rs
@@ -37,6 +37,14 @@ pub trait SourceControlProvider {
         event: &str,
     ) -> Result<(), Box<dyn Error>>;
 
+    /// Displays the diff between the PR branch and `origin/main`.
+    /// Assumes PR is already fetched and checked out.
+    fn show_diff(&self, pr_number: &str);
+
+    /// Pulls a PR locally and checks out a corresponding local branch.
+    /// Behavior differs depending on whether the PR comes from the same repo or a fork.
+    fn pull_pr(&self, pr_number: &str);
+
     /// Lists all open pull requests for the current repository.
     ///
     /// # Returns

--- a/src/providers/github/mod.rs
+++ b/src/providers/github/mod.rs
@@ -13,15 +13,3 @@ pub(crate) mod methods;
 // This module likely contains data structures, such as API response models, domain models, and data transfer objects (DTOs).
 // Making it public means these models can be used throughout the crate and by external users if the crate is published.
 pub mod models;
-
-// Re-export selected items from the `github` module at this level.
-// This makes `get_remote_url`, `pull_pr`, and `show_diff` available directly from this module,
-// allowing users to call these functions without explicitly referencing `github::`.
-// This technique improves ergonomics and provides a curated public API.
-//
-// For example:
-// Instead of `crate::providers::github::get_remote_url()`,
-// users can simply write `crate::providers::get_remote_url()`
-//
-// This helps organize code so the internal module structure can change without affecting external users.
-pub use self::github::{get_remote_url, pull_pr, show_diff};

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -1,38 +1,67 @@
-// Import the GitHub-specific provider and the generic SourceControlProvider trait.
-// This allows us to use GitHubProvider as a polymorphic implementation of the trait.
+// This module acts as the root module for defining and accessing source control providers.
+// Currently, it only supports GitHub, but is designed to be extensible to support
+// additional providers like GitLab, Bitbucket, etc., in the future.
+
+// Import the `SourceControlProvider` trait which defines the behavior any source control
+// provider must implement (e.g., listing PRs, submitting reviews, etc.)
 use crate::providers::github::methods::SourceControlProvider;
+
+// Import the concrete implementation of the provider for GitHub.
+// `GitHubProvider` is a struct that implements the `SourceControlProvider` trait.
 use crate::providers::github::models::GitHubProvider;
+
+// The Error trait from Rust's standard library is required to support flexible error handling
+// in the return types of provider factories and operations.
 use std::error::Error;
+
+// Re-export the GitHub provider module so other parts of the crate can access it.
+// This allows submodules like `github::methods` and `github::models` to be accessed
+// through the public `providers` namespace.
 pub mod github;
 
-/// Returns a boxed trait object implementing `SourceControlProvider` based on the remote URL.
+/// Attempts to select and construct a source control provider based on the provided remote URL.
 ///
-/// This function acts as a simple factory to choose the appropriate source control backend
-/// (currently only GitHub is supported).
+/// This function acts as a basic factory for determining which provider should be used
+/// based on the `remote_url` string. In this case, it checks for the presence of
+/// "github.com" and returns a GitHub provider.
 ///
 /// # Arguments
 ///
-/// * `remote_url` - The Git remote origin URL (e.g., from `git remote get-url origin`)
+/// * `remote_url` - The Git remote origin URL obtained via `git remote get-url origin`.
+///   This string is used to determine which source control provider the project is using.
 ///
 /// # Returns
 ///
-/// * `Ok(Box<dyn SourceControlProvider>)` if a provider is found and initialized successfully.
-/// * `Err(...)` if no supported provider matches the URL.
+/// * `Ok(Box<dyn SourceControlProvider>)` - If a compatible provider is found, it returns
+///   a boxed trait object allowing dynamic dispatch of trait methods (e.g., listing PRs).
+/// * `Err(...)` - If the remote URL does not match any known provider, an error is returned.
+///
+/// # Design Note
+///
+/// - The use of a boxed trait object (`Box<dyn SourceControlProvider>`) allows client code
+///   to interact with the provider generically without needing to know its exact type.
+/// - This approach simplifies adding new providers by updating only this function,
+///   while the rest of the code remains unchanged.
 ///
 /// # Example
 ///
-/// ```
-/// let provider = get_provider("https://github.com/owner/repo.git")?;
+/// ```rust
+/// let remote_url = "https://github.com/user/repo.git";
+/// let provider = get_provider(remote_url)?;
 /// provider.list_pull_requests()?;
-/// ``
+/// ```
 pub fn get_provider(remote_url: &str) -> Result<Box<dyn SourceControlProvider>, Box<dyn Error>> {
-    // Currently, only GitHub is supported.
-    // Check if the URL contains "github.com" as a simple heuristic.
+    // Simple pattern match on the remote URL.
+    // This check assumes that any GitHub remote will include "github.com" in the URL.
+    // In the future, more sophisticated matching or parsing logic may be used
+    // to support other providers like GitLab or Bitbucket.
     if remote_url.contains("github.com") {
-        // Return it as a boxed trait object so it can be used generically.
+        // Instantiate a new GitHub provider with the given URL.
+        // `.new()` may return an error, so the `?` operator is used to propagate it.
         Ok(Box::new(GitHubProvider::new(remote_url.to_string())?))
     } else {
-        // Return an error for any unsupported remote host.
+        // If the URL does not match any known provider, return a generic error.
+        // `.into()` converts the &str into a boxed error.
         Err("Unsupported provider".into())
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,8 @@
 // Bring the `env` module from the Rust standard library into scope.
 // This module provides functions for accessing environment variables.
 use std::env;
+// `Command` allows us to spawn system processes like invoking `git`.
+use std::process::Command;
 
 /// Determines whether debug logging or verbose diagnostics should be enabled,
 /// based on the presence and value of the `DEBUG` environment variable.
@@ -14,7 +16,7 @@ use std::env;
 /// - Accepts the values "1", "true", or "TRUE" to enable debug mode
 /// - Any other value, or if the variable is unset, disables debug mode
 ///
-/// # Example
+/// # Example:
 /// ```bash
 /// DEBUG=1 cargo run      # Debug mode ON
 /// DEBUG=true cargo run   # Debug mode ON
@@ -27,17 +29,23 @@ use std::env;
 pub fn is_debug_enabled() -> bool {
     // Attempt to read the value of the `DEBUG` environment variable.
     // `env::var()` returns a `Result<String, VarError>`.
-    //
-    // We use `.as_deref()` to convert `Result<String, _>` to `Result<&str, _>`
-    // which lets us match on the string contents directly without allocating.
+    // `.as_deref()` converts `Result<String, _>` to `Result<&str, _>` for easier matching.
     matches!(
         env::var("DEBUG").as_deref(),
-        // Match against a few common string values considered to mean "true".
-        // This is case-sensitive for "true", but includes uppercase variant as well.
+        // Match against known truthy values.
         Ok("1") | Ok("true") | Ok("TRUE")
     )
 }
 
+/// A macro for printing debug logs only when debugging is enabled via `DEBUG` env var.
+///
+/// It wraps `eprintln!` so logs go to stderr, and will only emit output if `is_debug_enabled()` is `true`.
+/// This allows lightweight insertion of debug logs without affecting performance in production.
+///
+/// # Usage:
+/// ```rust
+/// debug_log!("Loading config for user: {}", user_id);
+/// ```
 #[macro_export]
 macro_rules! debug_log {
     ($($arg:tt)*) => {
@@ -45,4 +53,44 @@ macro_rules! debug_log {
             eprintln!($($arg)*);
         }
     };
+}
+
+/// Attempts to retrieve the `origin` remote URL from the local Git repository.
+///
+/// This function invokes the shell command `git remote get-url origin` and parses the output.
+/// It can be used to determine where the repo was cloned from, useful for identifying provider (e.g., GitHub).
+///
+/// # Returns:
+/// - `Some(String)` containing the remote URL if successful.
+/// - `None` if Git fails or the command exits with a non-zero code.
+pub fn get_remote_url() -> Option<String> {
+    // Emit a debug message before executing the Git command, if debugging is enabled.
+    debug_log!("[DEBUG] Getting remote origin URL...");
+
+    // Use `git remote get-url origin` to retrieve the remote origin.
+    // This is the canonical way to get the upstream URL in Git.
+    let output = Command::new("git")
+        .args(["remote", "get-url", "origin"])
+        .output()
+        .expect("Failed to get remote URL"); // Panic if the command itself fails to launch
+
+    // Log raw output of Git command if debugging.
+    debug_log!(
+        "[DEBUG] Raw output: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+
+    if output.status.success() {
+        // Convert raw bytes to UTF-8 string, trim whitespace, and return.
+        let url = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        debug_log!("[DEBUG] Remote URL: {}", url);
+        Some(url)
+    } else {
+        // If Git command failed, optionally print an error if debugging is enabled.
+        debug_log!(
+            "[DEBUG] Failed to get remote URL (exit code: {})",
+            output.status
+        );
+        None
+    }
 }


### PR DESCRIPTION
## Summary of Improvements to `git-pr`

### Codebase Enhancements
- Deep commenting and documentation added across all critical modules:
   - CLI parsing and command dispatch (`main.rs`)
   - Moved Global functions to trait methods
   - Provider abstraction and GitHub-specific logic
   - Review submission flow, including `approval`, `rejection`, and `comment-only`
   - Pulling PRs: logic for **same-repo** vs **forked** scenarios
   - Showing detailed PR metadata: *commits*, *files*, *age*, *author*
   - Closing PRs cleanly via GitHub API, when `--reject` is used with `submit-review`
- Added debug logging via `debug_log!` macro to trace internal state and API calls.

### Pulling PRs
Handled both forked and non-forked PRs:
- Same-repo PRs:
   - Branch fetched and checked out locally.
   - Contributors with repo access can push updates directly.
- Forked PRs:
   - Fetched as read-only branches named `<username>-pr-<number>`.
   - Prevents pushing to fork.
Users must push updates to a new branch in the main repo.

> 🔁 This removes the need for a `--contribute` flag. Behavior is determined automatically based on repo origin.