### PR TITLE
Improve show diff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,6 +286,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_home"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -429,6 +435,7 @@ dependencies = [
  "serde_json",
  "tabled",
  "textwrap",
+ "which",
 ]
 
 [[package]]
@@ -1677,6 +1684,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fabb953106c3c8eea8306e4393700d7657561cb43122571b172bbfb7c7ba1d"
+dependencies = [
+ "env_home",
+ "rustix",
+ "winsafe",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1900,6 +1918,12 @@ name = "windows_x86_64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,4 @@ chrono = { version = "0.4", features = ["serde"] }
 textwrap = "0.16"
 tabled = { version = "0.20.0", features = ["ansi"] }
 owo-colors = "4.2.2"
+which = "8.0.0"

--- a/README.md
+++ b/README.md
@@ -90,22 +90,22 @@ export GITHUB_TOKEN=ghp_xxx123yourtoken
 All commands operate in the context of the GitHub repo defined by your local git remote.
 
 ```bash
-git-pr list
-git-pr pull <PR_NUMBER>
-git-pr show-diff <PR_NUMBER>
-git-pr submit-review <PR_NUMBER> --message "Looks great!"
-git pr show-details 5
+git pr list                                                 # Gets PR List
+git pr pull <PR_NUMBER>                                     # Pulls the PR locally
+git pr show-diff <PR_NUMBER>                                # Shows the PR diff
+git pr submit-review <PR_NUMBER> --message "Looks great!"   # Submits review
+git pr show-details 5                                       # Show details about the PR
 ```
 
 ## 🛠️ Command Reference
 
-| Command           | Description                         |
-|-------------------|-------------------------------------|
-| `list`            | List open pull requests             |
-| `pull <number>`   | Fetch and checkout a PR             |
-| `show-diff <num>` | Show diff between `main` and the PR |
-| `submit-review`   | Submit a review with a message      |
-| `show-details`    | Shows the details about the PR      |
+| Command                     | Description                         |
+|-----------------------------|-------------------------------------|
+| `list`                      | List open pull requests             |
+| `pull <pr_number>`          | Fetch and checkout a PR             |
+| `show-diff <pr_number>`     | Show diff between `main` and the PR |
+| `submit-review <pr_number>` | Submit a review with a message      |
+| `show-details <pr_number>`  | Shows the details about the PR      |
 
 ```bash
 git pr -help
@@ -168,26 +168,80 @@ Switched to branch 'pr-request-1'
 > Philosophy of pushing improvements or update the pull-request is simple:
 > - The PR is to same Repo
     >
+
 - The branch will be fetched, checked out and contributors with write access can push changes directly to the PR branch.
+
 > - The PR is from a forked Repo
     >
+
 - The PR is checked out locally as a new branch named `<fork-owner>-pr-<number>`, which cannot be pushed back to the
   fork. If needed, changes can be committed and pushed to a new branch in the original repo, continuing the work.
 
 #### Show the Diff
 
 ```bash
-> git pr show-diff 1
-🔍 Showing diff for PR #1...
+> git pr show-diff 7
+🔍 Showing diff for PR #7...
 
-README.md
+added: New-PR.md
 ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 
 ───┐
 1: │
 ───┘
-# testing-git-pr]
-## First PR to test
+## Adding README
+### Adding more to see if interactive works or not
+### It should be able to add
+
+removed: README.md
+───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+
+───┐
+0: │
+───┘
+## Adding README
+
+Testing.md
+───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+
+───┐
+1: │
+───┘
+# Testing Markdown file
+## Let's add few more lines
+```
+
+#### Show the Diff with `--raw`
+
+```bash
+git pr show-diff 7 --raw
+🔍 Showing diff for PR #7...
+diff --git a/New-PR.md b/New-PR.md
+new file mode 100644
+index 0000000..dbf6b10
+--- /dev/null
++++ b/New-PR.md
+@@ -0,0 +1,5 @@
++## Adding README
++
++### Adding more to see if interactive works or not
++
++### It should be able to add
+diff --git a/README.md b/README.md
+deleted file mode 100644
+index 89ff3ba..0000000
+--- a/README.md
++++ /dev/null
+@@ -1 +0,0 @@
+-## Adding README
+diff --git a/Testing.md b/Testing.md
+index 411c237..ae05846 100644
+--- a/Testing.md
++++ b/Testing.md
+@@ -1 +1,3 @@
+ # Testing Markdown file
++
++## Let's add few more lines
 ```
 
 #### Tried to review my own PR 😉

--- a/src/providers/github/methods.rs
+++ b/src/providers/github/methods.rs
@@ -30,7 +30,7 @@ pub trait SourceControlProvider {
     /// # Usage
     /// This method encapsulates the entire review submission flow, including authentication,
     /// sending the review comment, and handling response errors.
-    fn submit_review(
+    fn submit_pull_request_review(
         &self,
         pr_number: &str,
         message: &str,
@@ -38,12 +38,11 @@ pub trait SourceControlProvider {
     ) -> Result<(), Box<dyn Error>>;
 
     /// Displays the diff between the PR branch and `origin/main`.
-    /// Assumes PR is already fetched and checked out.
-    fn show_diff(&self, pr_number: &str);
+    fn show_pull_request_diff(&self, pr_number: &str, raw: bool) -> Result<(), Box<dyn Error>>;
 
     /// Pulls a PR locally and checks out a corresponding local branch.
     /// Behavior differs depending on whether the PR comes from the same repo or a fork.
-    fn pull_pr(&self, pr_number: &str);
+    fn get_pull_request(&self, pr_number: &str);
 
     /// Lists all open pull requests for the current repository.
     ///


### PR DESCRIPTION
## Functional Improvements
1. Improved `show-diff` Command
   - Now works without needing to pull the PR locally first.
   - Uses GitHub API to fetch the PR head ref and shows the diff against origin/main.
2. Added `--raw` flag to:
   - Print unformatted, raw diff directly to stdout (useful for scripting/grepping).
3. Smart Pager Detection:
   - Uses [delta](https://github.com/dandavison/delta) for pretty diffing (if installed)
   - Falls back to `less` or `cat` if `delta` is not found

## Error Handling & Typing Fixes
- Fixed a trait method signature error (E0053) for `show_diff`
- Handled unused Result properly to avoid warning spam
- More robust error messages for missing PRs, network failures, or bad diffs
- Expanded in-code documentation across all major functions